### PR TITLE
Typo on pip install instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Installing
 
 Using pip::
 
-    pip install redis_schamatics
+    pip install redis_schematics
 
 
 Understanding Persistence layers


### PR DESCRIPTION
Just a little typo in install instructions.
