### PR TITLE
Validate dump type before loads

### DIFF
--- a/redis_schematics/__init__.py
+++ b/redis_schematics/__init__.py
@@ -43,6 +43,8 @@ class BaseRedisMixin(object):
     @staticmethod
     def __deserializer__(dump):
         """Method used to deserialize to string prior to loading complex objects."""
+        if not isinstance(dump, str):
+            dump = str(dump, encoding='utf-8')
         return json.loads(dump)
 
     @property


### PR DESCRIPTION
## Type
- Bug fix

## Status
- Done

## Tasks

- [ ] Unit tests
- [ ] Integration tests
- [ ] Documentation
- [ ] Changelog

## Description

This PR adds a validation before loads the dump data. This fixes the problem that redis on Python 3 returns bytes instead of string

## Needs Release
- Bugfix
